### PR TITLE
Adapting helm source --fallback

### DIFF
--- a/helm-chronos.el
+++ b/helm-chronos.el
@@ -111,10 +111,24 @@
     (action . (("Add timer" . helm-chronos--parse-string-and-add-timer))))
   "Helm source to select from recent non-standard timers list.")
 
+;; (defvar helm-chronos--fallback-source
+;;   '((name . "Enter <expiry time spec>/<message>")
+;;     (candidates  . (list ""))
+;;     (action . (("Add timer" . helm-chronos--parse-string-and-add-timer))))
+;;   "Helm source to create a new timer")
+
 (defvar helm-chronos--fallback-source
-  '((name . "Enter <expiry time spec>/<message>")
-    (dummy)
-    (action . (("Add timer" . helm-chronos--parse-string-and-add-timer)))))
+  (helm-build-dummy-source "Enter <expiry time spec>/<message>"
+    :filtered-candidate-transformer
+    (lambda (_candidates _source)
+      (list (or (and (not (string= helm-pattern ""))
+		     helm-pattern)
+		"Enter a timer to start")))
+    :action '(("Add timer" . (lambda (candidate)
+			       (if (string= helm-pattern "")
+				   (message "No timer")
+				   (helm-chronos--parse-string-and-add-timer helm-pattern)))))))
+
 
 ;;;###autoload
 (defun helm-chronos-add-timer ()


### PR DESCRIPTION
In emacs 25 & up, helm-20170228.412, only one source is presented to the user. fallback-source doesn't work correctly. As no new timers are correctly created, recent timers do not show.
fallback-source modified, by replacing (dummy) in the helm - function/macro by (helm-build-dummy-source).
I'm not a programmer, and I'm neither into lisp, nor into helm. However, the code works that way on my machine. 
Note to David Knight: if useful, please use, and David, thank you for a lovely idea and beautiful code.